### PR TITLE
Soo, nun nochmal komplett!

### DIFF
--- a/tools/teensy-prog/client/main.c
+++ b/tools/teensy-prog/client/main.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
     if (hexFile[0] != 0) {
         hexFD = fopen(hexFile,"rb");
         if (hexFD == 0) {
-            printf("unable to open hex file");
+            printf("unable to open hex file\n");
             errorParsing = 1;
         }
     }
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	// open serial port
 	serialFD = open(serialPort, O_RDWR | O_NOCTTY);
 	if (serialFD == -1) {
-		printf("unable to open serial port");
+		printf("unable to open serial port \"%s\"\n", serialPort);
 		errorParsing = 1;
 	}
 

--- a/tools/teensy-prog/teensy/.gitignore
+++ b/tools/teensy-prog/teensy/.gitignore
@@ -1,0 +1,5 @@
+*.eep
+*.elf
+*.lss
+*.o
+.dep

--- a/tools/teensy-prog/teensy/Makefile
+++ b/tools/teensy-prog/teensy/Makefile
@@ -93,7 +93,7 @@ ASRC =
 # Optimization level, can be [0, 1, 2, 3, s]. 
 #     0 = turn off optimization. s = optimize for size.
 #     (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-OPT = s
+OPT = 2
 
 
 # Debugging format.

--- a/tools/teensy-prog/teensy/immeFlash.c
+++ b/tools/teensy-prog/teensy/immeFlash.c
@@ -6,6 +6,10 @@
 
 #define CPU_PRESCALE(n) (CLKPR = 0x80, CLKPR = (n))
 
+#define LED_DDR     DDRD
+#define LED_PORT    PORTD
+#define LED_BIT     _BV(PD6)
+
 #define DBG_DDR  DDRF
 #define DBG_PORT PORTF
 #define RST      16
@@ -20,70 +24,70 @@
 
 void init(void) 
 {
-	//DBG_PORT = 0x00;
+    //DBG_PORT = 0x00;
 
-	// reset low
-	DBG_PORT &= ~RST;
-	_delay_us(US_DELAY);
+    // reset low
+    DBG_PORT &= ~RST;
+    _delay_us(US_DELAY);
 
-	// dbg clock high
-	DBG_PORT ^= DB_CLK;
-	_delay_us(US_DELAY);
-	// dbg clock low
-	DBG_PORT ^= DB_CLK;
-	_delay_us(US_DELAY);
-	// dbg clock high
-	DBG_PORT ^= DB_CLK;
-	_delay_us(US_DELAY);
-	// dbg clock low
-	DBG_PORT ^= DB_CLK;
+    // dbg clock high
+    DBG_PORT ^= DB_CLK;
+    _delay_us(US_DELAY);
+    // dbg clock low
+    DBG_PORT ^= DB_CLK;
+    _delay_us(US_DELAY);
+    // dbg clock high
+    DBG_PORT ^= DB_CLK;
+    _delay_us(US_DELAY);
+    // dbg clock low
+    DBG_PORT ^= DB_CLK;
 
-	// reset high
-	_delay_us(US_DELAY);
-	DBG_PORT |= RST;
+    // reset high
+    _delay_us(US_DELAY);
+    DBG_PORT |= RST;
 
 }
 
 uint8_t send_byte(uint8_t data)
 {
-	for (int j = 0; j < 8; ++j) {
+    for (int j = 0; j < 8; ++j) {
 
-		if (data & 0x80)
-			DBG_PORT |= DATA_OUT;
-		else
-			DBG_PORT &= ~DATA_OUT;
+        if (data & 0x80)
+            DBG_PORT |= DATA_OUT;
+        else
+            DBG_PORT &= ~DATA_OUT;
 
-		data <<= 1;
+        data <<= 1;
 
-		_delay_us(US_DELAY);
-		// dbg clock high
-		DBG_PORT |= DB_CLK;
+        _delay_us(US_DELAY);
+        // dbg clock high
+        DBG_PORT |= DB_CLK;
 
-		_delay_us(US_DELAY);
+        _delay_us(US_DELAY);
 
-		// dbg clock low
-		DBG_PORT &= ~DB_CLK;
+        // dbg clock low
+        DBG_PORT &= ~DB_CLK;
 
-		// sample
-		if (PINF & DATA_IN)
-			data |= 1;
-	}
-	return data;	
+        // sample
+        if (PINF & DATA_IN)
+            data |= 1;
+    }
+    return data;    
 }
 
 
 
 void chip_erase(void)
 {
-	send_byte(0x14);
-	send_byte(0); // ignore sent value
+    send_byte(0x14);
+    send_byte(0); // ignore sent value
 }
 
 void write_config(uint8_t cfg)
 {
-	send_byte(0x1D);	
-	send_byte(cfg & 0x0F);	
-	send_byte(0); // ignore sent value
+    send_byte(0x1D);    
+    send_byte(cfg & 0x0F);  
+    send_byte(0); // ignore sent value
 }
 
 // status bits received by read_status()
@@ -98,52 +102,52 @@ void write_config(uint8_t cfg)
 
 uint8_t read_status(void)
 {
-	send_byte(0x34);
-	return send_byte(0);
+    send_byte(0x34);
+    return send_byte(0);
 }
 
 uint16_t get_chip_id(void)
 {
-	send_byte(0x68);
-	uint16_t result = send_byte(0);
-	result |= send_byte(0) << 8;
-	return result;
+    send_byte(0x68);
+    uint16_t result = send_byte(0);
+    result |= send_byte(0) << 8;
+    return result;
 }
 
 void cpu_halt(void)
 {
-	send_byte(0x44);
-	send_byte(0); // ignore sent value
+    send_byte(0x44);
+    send_byte(0); // ignore sent value
 }
 
 void cpu_resume(void)
 {
-	send_byte(0x4C);
-	send_byte(0); // ignore sent value
+    send_byte(0x4C);
+    send_byte(0); // ignore sent value
 }
 
 uint8_t debug_instr_1(uint8_t in0)
 {
-	send_byte(0x55);	
-	send_byte(in0);	
-	return send_byte(0);
+    send_byte(0x55);    
+    send_byte(in0); 
+    return send_byte(0);
 }
 
 uint8_t debug_instr_2(uint8_t in0, uint8_t in1)
 {
-	send_byte(0x56);	
-	send_byte(in0);	
-	send_byte(in1);	
-	return send_byte(0);
+    send_byte(0x56);    
+    send_byte(in0); 
+    send_byte(in1); 
+    return send_byte(0);
 }
 
 uint8_t debug_instr_3(uint8_t in0, uint8_t in1, uint8_t in2)
 {
-	send_byte(0x57);	
-	send_byte(in0);	
-	send_byte(in1);	
-	send_byte(in2);	
-	return send_byte(0);
+    send_byte(0x57);    
+    send_byte(in0); 
+    send_byte(in1); 
+    send_byte(in2); 
+    return send_byte(0);
 }
 
 void read_code_memory(uint16_t address, 
@@ -151,63 +155,63 @@ void read_code_memory(uint16_t address,
                       uint16_t count, 
                       uint8_t *outputData)
 {
-	if (address >= 0x8000)
-		address = (address & 0x7FFF) + (bank * 0x8000);
+    if (address >= 0x8000)
+        address = (address & 0x7FFF) + (bank * 0x8000);
 
-	debug_instr_3(0x75,0xC7,(bank * 16) + 1);
-	debug_instr_3(0x90,address >> 8,address);
-	for (int i = 0; i < count; ++i) {
-		debug_instr_1(0xE4);
-		outputData[i] = debug_instr_1(0x93);
-		debug_instr_1(0xA3);
-	}
+    debug_instr_3(0x75,0xC7,(bank * 16) + 1);
+    debug_instr_3(0x90,address >> 8,address);
+    for (int i = 0; i < count; ++i) {
+        debug_instr_1(0xE4);
+        outputData[i] = debug_instr_1(0x93);
+        debug_instr_1(0xA3);
+    }
 }
 
 void read_xcode_memory(uint16_t address, 
                        uint16_t count, 
                        uint8_t *outputData)
 {
-	debug_instr_3(0x90,address >> 8,address);
-	for (int i = 0; i < count; ++i) {
-		outputData[i] = debug_instr_1(0xE0);
-		debug_instr_1(0xA3);
-	}	
+    debug_instr_3(0x90,address >> 8,address);
+    for (int i = 0; i < count; ++i) {
+        outputData[i] = debug_instr_1(0xE0);
+        debug_instr_1(0xA3);
+    }   
 }
 
 void write_xdata_memory(uint16_t address, 
                         uint16_t count, 
                         uint8_t *inputData)
 {
-	debug_instr_3(0x90,address >> 8,address);
-	for (int i = 0; i < count; ++i) {
-		debug_instr_2(0x74,inputData[i]);
-		debug_instr_1(0xF0);
-		debug_instr_1(0xA3);	
-	}
+    debug_instr_3(0x90,address >> 8,address);
+    for (int i = 0; i < count; ++i) {
+        debug_instr_2(0x74,inputData[i]);
+        debug_instr_1(0xF0);
+        debug_instr_1(0xA3);    
+    }
 }
 
 void set_pc(uint16_t address)
 {
-	debug_instr_3(0x02,address >> 8,address);
+    debug_instr_3(0x02,address >> 8,address);
 }
 
 void clock_init(void)
 {
-	debug_instr_3(0x75,0xC6,0x00);
-	uint8_t sleepReg;
-	do {
-	    _delay_us(1000);
-		sleepReg = debug_instr_2(0xE5,0xBE);
-	} while (!(sleepReg & 0x40));
+    debug_instr_3(0x75,0xC6,0x00);
+    uint8_t sleepReg;
+    do {
+        _delay_us(1000);
+        sleepReg = debug_instr_2(0xE5,0xBE);
+    } while (!(sleepReg & 0x40));
 }
 
 void write_flash_page(uint32_t address, 
                       uint8_t *inputData,
-					  uint8_t  erase_page)
+                      uint8_t  erase_page)
 {
-	uint8_t updProc[] = { 0x75, 0xAD, ((address >> 8) / FLASH_WORD_SIZE) & 0x7E,
+    uint8_t updProc[] = { 0x75, 0xAD, ((address >> 8) / FLASH_WORD_SIZE) & 0x7E,
                           0x75, 0xAC, 0x00, 
-						  0x75, 0xAB, 0x23, 0x00,
+                          0x75, 0xAB, 0x23, 0x00,
                           0x75, 0xAE, 0x01, // ------
                           0xE5, 0xAE,       // erase code
                           0x20, 0xE7, 0xFB, // ------
@@ -225,46 +229,46 @@ void write_flash_page(uint32_t address,
                           0xDE, 0xF1,
                           0xDF, 0xEF,
                           0xA5
-	};
+    };
 
-	uint8_t updProcSize = sizeof(updProc);
+    uint8_t updProcSize = sizeof(updProc);
 
-	// remove code section for erase from updProc
+    // remove code section for erase from updProc
 /*
-	if (!erase_page) {
-		for (int i = 14; i < updProcSize; ++i)
-			updProc[i-8] = updProc[i];
-		updProcSize -= 8;
-	}
+    if (!erase_page) {
+        for (int i = 14; i < updProcSize; ++i)
+            updProc[i-8] = updProc[i];
+        updProcSize -= 8;
+    }
 */
-	write_xdata_memory(0xF000,  FLASHPAGE_SIZE, inputData);
+    write_xdata_memory(0xF000,  FLASHPAGE_SIZE, inputData);
     write_xdata_memory(0xF000 + FLASHPAGE_SIZE, updProcSize, updProc);
-	debug_instr_3(0x75,0xC7,0x51);
-	set_pc(0xF000 + FLASHPAGE_SIZE);
-	cpu_resume();
-	uint8_t status;
-	do {
-		_delay_ms(100);
-		status = read_status();
-	} while (!(status & ST_CPU_HALTED));
+    debug_instr_3(0x75,0xC7,0x51);
+    set_pc(0xF000 + FLASHPAGE_SIZE);
+    cpu_resume();
+    uint8_t status;
+    do {
+        _delay_ms(100);
+        status = read_status();
+    } while (!(status & ST_CPU_HALTED));
 }
 
 
 void read_flash_page(uint32_t address, uint8_t *outputData)
 {
-	read_code_memory(address & 0xFFFF, 
+    read_code_memory(address & 0xFFFF, 
                      (address >> 15) & 0x03, FLASHPAGE_SIZE, outputData);
 }
 
 void mass_erase_flash(void)
 {
-	debug_instr_1(0x00);
-	chip_erase();
-	uint8_t status = 0;
-	do {
-	    _delay_ms(100);
-		status = read_status();
-	} while (!(status & ST_CHIP_ERASE_DONE));
+    debug_instr_1(0x00);
+    chip_erase();
+    uint8_t status = 0;
+    do {
+        _delay_ms(100);
+        status = read_status();
+    } while (!(status & ST_CHIP_ERASE_DONE));
 }
 
 
@@ -275,92 +279,96 @@ void mass_erase_flash(void)
 
 int main(void)
 {
-	// set for 16 MHz clock
-	CPU_PRESCALE(1);
+    // set for 16 MHz clock
+    CPU_PRESCALE(1);
 
-	// initialize the USB, and then wait for the host
-	// to set configuration.  If the Teensy is powered
-	// without a PC connected to the USB port, this 
-	// will wait forever.
-	usb_init();
-	while (!usb_configured()) /* wait */ ;
-	_delay_ms(100);
+    LED_DDR  |= LED_BIT;
+    LED_PORT |= LED_BIT;
 
-	int16_t r;
-	uint8_t cmd;
+    // initialize the USB, and then wait for the host
+    // to set configuration.  If the Teensy is powered
+    // without a PC connected to the USB port, this
+    // will wait forever.
+    usb_init();
+    while (!usb_configured()) /* wait */ ;
+    _delay_ms(100);
 
-	DBG_DDR = RST | DB_CLK | DATA_OUT;
-	DBG_PORT = RST;
+    int16_t r;
+    uint8_t cmd;
 
-	while (1) {
-		// read command
-		r = usb_serial_getchar();		
-		if (r != -1) {
-			init();
-			clock_init();
-			cmd = r;
-			if (cmd & STATUS_CMD) {
-				uint8_t status = read_status();
-				do {
-					r = usb_serial_putchar(status);
-				} while (r == -1);
-			}
-			if (cmd & CPUID_CMD) {
-				uint16_t chipInfo = get_chip_id();
-				do {
-					r = usb_serial_putchar(chipInfo & 0xFF);
-				} while (r == -1);
-				do {
-					r = usb_serial_putchar((chipInfo >> 8) & 0xFF);
-				} while (r == -1);
-			}
-			if (cmd & ERASE_CMD) {
-				mass_erase_flash();
-				do {
-					r = usb_serial_putchar('A');
-				} while (r == -1);
-			}
-			if (cmd & PROG_CMD) {
-				
-				uint8_t pageBuf[FLASHPAGE_SIZE];
+    DBG_DDR = RST | DB_CLK | DATA_OUT;
+    DBG_PORT = RST;
 
-				uint8_t i = 0;
-				while (1) {
-					r = usb_serial_getchar();
-					if (r == 0xFF) {
-						do {
-							r = usb_serial_putchar(0xFF);
-						} while (r == -1);
-						for (int j = 0; j < FLASHPAGE_SIZE; ++j) {
-							do {
-								r = usb_serial_getchar();
-							} while (r == -1);
-							pageBuf[j] = r;
-						}
-						uint32_t pageAddr = (uint32_t)i * (uint32_t)FLASHPAGE_SIZE;
-						write_flash_page(pageAddr,pageBuf,0);
-						read_flash_page(pageAddr,pageBuf);
-						for (int j = 0; j < FLASHPAGE_SIZE; ++j) {
-							do {
-								r = usb_serial_putchar(pageBuf[j]);
-							} while (r == -1);
-						}
-						do {
-							r = usb_serial_putchar(0x00);
-						} while (r == -1);
-						i++;
-					} else if (r == 0xF0) {
-						--i;
-					} else if (r == 0x11) {
-						set_pc(0xF000);
-						cpu_resume();
-						break;
-					}
-				}
-			
-			}
-		}
-	}
+    while (1) {
+        LED_PORT &= ~LED_BIT;
+        // read command
+        r = usb_serial_getchar();
+        if (r == -1)
+            continue;
+        LED_PORT |= LED_BIT;
+        init();
+        clock_init();
+        cmd = r;
+        if (cmd & STATUS_CMD) {
+            uint8_t status = read_status();
+            do {
+                r = usb_serial_putchar(status);
+            } while (r == -1);
+        }
+        if (cmd & CPUID_CMD) {
+            uint16_t chipInfo = get_chip_id();
+            do {
+                r = usb_serial_putchar(chipInfo & 0xFF);
+            } while (r == -1);
+            do {
+                r = usb_serial_putchar((chipInfo >> 8) & 0xFF);
+            } while (r == -1);
+        }
+        if (cmd & ERASE_CMD) {
+            mass_erase_flash();
+            do {
+                r = usb_serial_putchar('A');
+            } while (r == -1);
+        }
+        if (cmd & PROG_CMD) {
+
+            uint8_t pageBuf[FLASHPAGE_SIZE];
+
+            uint8_t i = 0;
+            while (1) {
+                r = usb_serial_getchar();
+                if (r == 0xFF) {
+                    do {
+                        r = usb_serial_putchar(0xFF);
+                    } while (r == -1);
+                    for (int j = 0; j < FLASHPAGE_SIZE; ++j) {
+                        do {
+                            r = usb_serial_getchar();
+                        } while (r == -1);
+                        pageBuf[j] = r;
+                    }
+                    uint32_t pageAddr = (uint32_t)i * (uint32_t)FLASHPAGE_SIZE;
+                    write_flash_page(pageAddr,pageBuf,0);
+                    read_flash_page(pageAddr,pageBuf);
+                    for (int j = 0; j < FLASHPAGE_SIZE; ++j) {
+                        do {
+                            r = usb_serial_putchar(pageBuf[j]);
+                        } while (r == -1);
+                    }
+                    do {
+                        r = usb_serial_putchar(0x00);
+                    } while (r == -1);
+                    i++;
+                } else if (r == 0xF0) {
+                    --i;
+                } else if (r == 0x11) {
+                    set_pc(0xF000);
+                    cpu_resume();
+                    break;
+                }
+            }
+        }
+    }
 }
 
 

--- a/tools/teensy-prog/teensy/immeFlash.c
+++ b/tools/teensy-prog/teensy/immeFlash.c
@@ -50,10 +50,10 @@ inline uint8_t recv_byte(void)
     return SPDR;
 }
 
-uint8_t chip_erase(void)
+void chip_erase(void)
 {
-	send_byte(0x14);
-	return recv_byte();
+    send_byte(0x14);
+    recv_byte(); // ignore sent value
 }
 
 void write_config(uint8_t cfg)


### PR DESCRIPTION
Moin Jochen!

Eigentlich sollte das auch mit Spannungsteilern funktionieren:
- PB0/RESET -> Per Spannungsteiler an Reset
- PB1/CLK -> Per Spannungsteiler an DC
- PB2/MOSI -> Per Spannungsteiler an DD
- PB3/MISO -> Direkt an DD

Programmieren geht danach ohne Verify-Fehler und der Fahrplan flasht so in 3.5s statt 20.
